### PR TITLE
Fix errors in calling MCP tools, add some super parameters.

### DIFF
--- a/packages/dartantic_ai/lib/src/mcp_client.dart
+++ b/packages/dartantic_ai/lib/src/mcp_client.dart
@@ -129,7 +129,7 @@ class McpClient {
     if (!isConnected) await _connect();
 
     final result = await _client!.callTool(
-      mcp.CallToolRequestParams(name: toolName, arguments: arguments),
+      mcp.CallToolRequest(name: toolName, arguments: arguments ?? {}),
     );
 
     // Convert MCP result to simple format

--- a/samples/dartantic_cli/lib/src/commands/chat_command.dart
+++ b/samples/dartantic_cli/lib/src/commands/chat_command.dart
@@ -8,13 +8,12 @@ import '../exit_codes.dart';
 import '../mcp/mcp_tool_collector.dart';
 import '../prompt/prompt_processor.dart';
 import '../settings/settings.dart';
-import '../settings/settings_loader.dart';
 import 'base_command.dart';
 import 'utils.dart';
 
 /// Command to send a chat prompt to an AI agent.
 class ChatCommand extends DartanticCommand with PromptCommandMixin {
-  ChatCommand(SettingsLoader settingsLoader) : super(settingsLoader) {
+  ChatCommand(super.settingsLoader) {
     argParser
       ..addOption(
         'prompt',

--- a/samples/dartantic_cli/lib/src/commands/embed_create_command.dart
+++ b/samples/dartantic_cli/lib/src/commands/embed_create_command.dart
@@ -5,12 +5,11 @@ import 'package:dartantic_ai/dartantic_ai.dart';
 
 import '../embeddings/chunker.dart';
 import '../exit_codes.dart';
-import '../settings/settings_loader.dart';
 import 'base_command.dart';
 
 /// Command to create embeddings from text files.
 class EmbedCreateCommand extends DartanticCommand {
-  EmbedCreateCommand(SettingsLoader settingsLoader) : super(settingsLoader) {
+  EmbedCreateCommand(super.settingsLoader) {
     argParser
       ..addOption(
         'chunk-size',

--- a/samples/dartantic_cli/lib/src/commands/embed_search_command.dart
+++ b/samples/dartantic_cli/lib/src/commands/embed_search_command.dart
@@ -4,12 +4,11 @@ import 'dart:io';
 import 'package:dartantic_ai/dartantic_ai.dart';
 
 import '../exit_codes.dart';
-import '../settings/settings_loader.dart';
 import 'base_command.dart';
 
 /// Command to search embeddings with a query.
 class EmbedSearchCommand extends DartanticCommand {
-  EmbedSearchCommand(SettingsLoader settingsLoader) : super(settingsLoader) {
+  EmbedSearchCommand(super.settingsLoader) {
     argParser.addOption(
       'query',
       abbr: 'q',

--- a/samples/dartantic_cli/lib/src/commands/generate_command.dart
+++ b/samples/dartantic_cli/lib/src/commands/generate_command.dart
@@ -4,13 +4,12 @@ import 'package:dartantic_ai/dartantic_ai.dart';
 
 import '../exit_codes.dart';
 import '../prompt/prompt_processor.dart';
-import '../settings/settings_loader.dart';
 import 'base_command.dart';
 import 'utils.dart';
 
 /// Command to generate media content.
 class GenerateCommand extends DartanticCommand with PromptCommandMixin {
-  GenerateCommand(SettingsLoader settingsLoader) : super(settingsLoader) {
+  GenerateCommand(super.settingsLoader) {
     argParser
       ..addOption(
         'prompt',

--- a/samples/dartantic_cli/lib/src/commands/models_command.dart
+++ b/samples/dartantic_cli/lib/src/commands/models_command.dart
@@ -3,12 +3,11 @@ import 'dart:io';
 import 'package:dartantic_ai/dartantic_ai.dart';
 
 import '../exit_codes.dart';
-import '../settings/settings_loader.dart';
 import 'base_command.dart';
 
 /// Command to list available models for a provider.
 class ModelsCommand extends DartanticCommand {
-  ModelsCommand(SettingsLoader settingsLoader) : super(settingsLoader);
+  ModelsCommand(super.settingsLoader);
 
   @override
   final String name = 'models';


### PR DESCRIPTION
# Description

Mainly, this fixes a compilation error in `packages/dartantic_ai/lib/src/mcp_client.dart` for some versions of the `mcp_dart` package.  My pubspec has:

```yaml
  dartantic_ai: ^2.0.1
  dartantic_interface: ^2.0.0
```

and pub resolved `mcp_dart` to 1.1.0, which doesn't take a nullable in `CallToolRequest`, so I fixed it.

I also made some parameters into super parameters for readability (it was giving analyzer infos), which allowed removing some imports.