### PR TITLE
feat: thought signatures

### DIFF
--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_message_mappers.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_message_mappers.dart
@@ -16,12 +16,20 @@ import 'google_chat.dart'
 final Logger _logger = Logger('dartantic.chat.mappers.google');
 
 /// Maps Dartantic Parts to Google gl.Parts (public helper for reuse).
+///
+/// The [messageMetadata] parameter should contain thought signatures when
+/// available, keyed as `'_google_thought_signatures'` with a map of
+/// tool call ID → signature.
 List<gl.Part> mapPartsToGoogle(
   Iterable<Part> parts, {
   bool includeToolCalls = false,
   bool includeToolResults = false,
+  Map<String, dynamic> messageMetadata = const {},
 }) {
   final mappedParts = <gl.Part>[];
+  final thoughtSignatures =
+      messageMetadata['_google_thought_signatures'] as Map<String, dynamic>? ??
+      const {};
 
   for (final part in parts) {
     switch (part) {
@@ -44,9 +52,9 @@ List<gl.Part> mapPartsToGoogle(
         );
       case ToolPart(:final kind):
         if (includeToolCalls && kind == ToolPartKind.call) {
-          mappedParts.add(_mapToolCallPart(part));
+          mappedParts.add(_mapToolCallPart(part, thoughtSignatures));
         } else if (includeToolResults && kind == ToolPartKind.result) {
-          mappedParts.add(_mapToolResultPart(part));
+          mappedParts.add(_mapToolResultPart(part, thoughtSignatures));
         }
       default:
         break;
@@ -56,7 +64,10 @@ List<gl.Part> mapPartsToGoogle(
   return mappedParts;
 }
 
-gl.Part _mapToolCallPart(ToolPart part) {
+gl.Part _mapToolCallPart(
+  ToolPart part,
+  Map<String, dynamic> thoughtSignatures,
+) {
   final arguments = part.arguments ?? const <String, dynamic>{};
   final callId = part.id.isNotEmpty
       ? part.id
@@ -72,11 +83,14 @@ gl.Part _mapToolCallPart(ToolPart part) {
       name: part.name,
       args: ProtobufValueHelpers.structFromJson(arguments),
     ),
-    thoughtSignature: part.thoughtSignature,
+    thoughtSignature: thoughtSignatures[callId],
   );
 }
 
-gl.Part _mapToolResultPart(ToolPart part) {
+gl.Part _mapToolResultPart(
+  ToolPart part,
+  Map<String, dynamic> thoughtSignatures,
+) {
   final responseMap = ToolResultHelpers.ensureMap(part.result);
   _logger.fine('Creating function response for tool: ${part.name}');
 
@@ -86,7 +100,7 @@ gl.Part _mapToolResultPart(ToolPart part) {
       name: part.name,
       response: ProtobufValueHelpers.structFromJson(responseMap),
     ),
-    thoughtSignature: part.thoughtSignature,
+    thoughtSignature: thoughtSignatures[part.id],
   );
 }
 
@@ -153,6 +167,7 @@ extension MessageListMapper on List<ChatMessage> {
         message.parts,
         includeToolCalls: false,
         includeToolResults: true,
+        messageMetadata: message.metadata,
       ),
       role: 'user',
     );
@@ -165,6 +180,7 @@ extension MessageListMapper on List<ChatMessage> {
         message.parts,
         includeToolCalls: true,
         includeToolResults: false,
+        messageMetadata: message.metadata,
       ),
       role: 'model',
     );
@@ -183,6 +199,7 @@ extension MessageListMapper on List<ChatMessage> {
           message.parts,
           includeToolCalls: false,
           includeToolResults: true,
+          messageMetadata: message.metadata,
         ),
       );
     }
@@ -194,10 +211,12 @@ extension MessageListMapper on List<ChatMessage> {
     Iterable<Part> parts, {
     required bool includeToolCalls,
     required bool includeToolResults,
+    Map<String, dynamic> messageMetadata = const {},
   }) => mapPartsToGoogle(
     parts,
     includeToolCalls: includeToolCalls,
     includeToolResults: includeToolResults,
+    messageMetadata: messageMetadata,
   );
 }
 
@@ -215,6 +234,8 @@ extension GenerateContentResponseMapper on gl.GenerateContentResponse {
     final executableCodeParts = <gl.ExecutableCode>[];
     final executionResults = <gl.CodeExecutionResult>[];
     final thinkingBuffer = StringBuffer();
+    // Collect thought signatures keyed by tool call ID for Gemini 3+ models
+    final thoughtSignatures = <String, dynamic>{};
 
     final contentParts = candidate.content?.parts ?? const <gl.Part>[];
     _logger.fine(
@@ -260,13 +281,13 @@ extension GenerateContentResponseMapper on gl.GenerateContentResponse {
                 arguments: args,
               );
         parts.add(
-          ToolPart.call(
-            id: callId,
-            name: functionCall.name,
-            arguments: args,
-            thoughtSignature: part.thoughtSignature,
-          ),
+          ToolPart.call(id: callId, name: functionCall.name, arguments: args),
         );
+        // Store thought signature in message metadata keyed by tool call ID
+        final sig = part.thoughtSignature;
+        if (sig.isNotEmpty) {
+          thoughtSignatures[callId] = sig;
+        }
       }
 
       final functionResponse = part.functionResponse;
@@ -286,9 +307,13 @@ extension GenerateContentResponseMapper on gl.GenerateContentResponse {
             id: responseId,
             name: functionResponse.name,
             result: responseMap,
-            thoughtSignature: part.thoughtSignature,
           ),
         );
+        // Store thought signature for function responses too
+        final sig = part.thoughtSignature;
+        if (sig.isNotEmpty) {
+          thoughtSignatures[responseId] = sig;
+        }
       }
 
       final executableCode = part.executableCode;
@@ -302,7 +327,17 @@ extension GenerateContentResponseMapper on gl.GenerateContentResponse {
       }
     }
 
-    final message = ChatMessage(role: ChatMessageRole.model, parts: parts);
+    // Build message metadata including thought signatures if present
+    final messageMetadata = <String, dynamic>{
+      if (thoughtSignatures.isNotEmpty)
+        '_google_thought_signatures': thoughtSignatures,
+    };
+
+    final message = ChatMessage(
+      role: ChatMessageRole.model,
+      parts: parts,
+      metadata: messageMetadata,
+    );
 
     final metadata = <String, dynamic>{
       'model': model,

--- a/packages/dartantic_interface/lib/src/chat/chat_message.dart
+++ b/packages/dartantic_interface/lib/src/chat/chat_message.dart
@@ -360,7 +360,6 @@ class ToolPart extends Part {
     required this.id,
     required this.name,
     required this.arguments,
-    this.thoughtSignature,
   }) : kind = ToolPartKind.call,
        result = null;
 
@@ -369,7 +368,6 @@ class ToolPart extends Part {
     required this.id,
     required this.name,
     required this.result,
-    this.thoughtSignature,
   }) : kind = ToolPartKind.result,
        arguments = null;
 
@@ -388,9 +386,6 @@ class ToolPart extends Part {
   /// The result of a tool execution (null for calls).
   final dynamic result;
 
-  /// The thought signature for the tool call.
-  final dynamic thoughtSignature;
-
   /// The arguments as a JSON string.
   String get argumentsRaw => arguments != null
       ? (arguments!.isEmpty ? '{}' : _jsonEncode(arguments))
@@ -405,8 +400,7 @@ class ToolPart extends Part {
           id == other.id &&
           name == other.name &&
           _mapEquals(arguments, other.arguments) &&
-          result == other.result &&
-          thoughtSignature == other.thoughtSignature;
+          result == other.result;
 
   @override
   int get hashCode =>
@@ -414,17 +408,14 @@ class ToolPart extends Part {
       id.hashCode ^
       name.hashCode ^
       arguments.hashCode ^
-      result.hashCode ^
-      thoughtSignature.hashCode;
+      result.hashCode;
 
   @override
   String toString() {
     if (kind == ToolPartKind.call) {
-      return 'ToolPart.call(id: $id, name: $name, arguments: $arguments, '
-          'thoughtSignature: $thoughtSignature)';
+      return 'ToolPart.call(id: $id, name: $name, arguments: $arguments)';
     } else {
-      return 'ToolPart.result(id: $id, name: $name, result: $result, '
-          'thoughtSignature: $thoughtSignature)';
+      return 'ToolPart.result(id: $id, name: $name, result: $result)';
     }
   }
 }


### PR DESCRIPTION
Relates to #85 copies over the thought signature into the tool parts returned from google. 

Without this change the included new test would fail with this error:

```sh

StatusException: Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, and missing thought_signature may lead to degraded model performance. Additional data, function call `default_api:string_tool` , position 2. Please refer to https://ai.google.dev/gemini-api/docs/thought-signatures for more details.
package:google_cloud_rpc/service_client.dart 240:5  ServiceClient._throwException
package:google_cloud_rpc/service_client.dart 181:7  ServiceClient._makeStreamingRequest

```