### PR TITLE
feat(google): add URL context server-side tool support

### DIFF
--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_model.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_model.dart
@@ -99,6 +99,14 @@ class GoogleChatModel extends ChatModel<GoogleChatModelOptions> {
         outputSchema == null &&
         serverSideTools.contains(GoogleServerSideTool.codeExecution);
 
+    final enableGoogleSearch =
+        outputSchema == null &&
+        serverSideTools.contains(GoogleServerSideTool.googleSearch);
+
+    final enableUrlContext =
+        outputSchema == null &&
+        serverSideTools.contains(GoogleServerSideTool.urlContext);
+
     final generationConfig = _buildGenerationConfig(
       options: options,
       outputSchema: outputSchema,
@@ -132,9 +140,8 @@ class GoogleChatModel extends ChatModel<GoogleChatModelOptions> {
       tools:
           toolsToSend.toToolList(
             enableCodeExecution: enableCodeExecution,
-            enableGoogleSearch:
-                outputSchema == null &&
-                serverSideTools.contains(GoogleServerSideTool.googleSearch),
+            enableGoogleSearch: enableGoogleSearch,
+            enableUrlContext: enableUrlContext,
           ) ??
           const [],
     );

--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_message_mappers.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_message_mappers.dart
@@ -494,12 +494,14 @@ extension ChatToolListMapper on List<Tool>? {
   List<gl.Tool>? toToolList({
     required bool enableCodeExecution,
     required bool enableGoogleSearch,
+    required bool enableUrlContext,
   }) {
     final hasTools = this != null && this!.isNotEmpty;
     _logger.fine(
       'Converting tools to Google format: hasTools=$hasTools, '
       'enableCodeExecution=$enableCodeExecution, '
       'enableGoogleSearch=$enableGoogleSearch, '
+      'enableUrlContext=$enableUrlContext, '
       'toolCount=${this?.length ?? 0}',
     );
 
@@ -520,10 +522,12 @@ extension ChatToolListMapper on List<Tool>? {
 
     final codeExecution = enableCodeExecution ? gl.CodeExecution() : null;
     final googleSearch = enableGoogleSearch ? gl.Tool_GoogleSearch() : null;
+    final urlContext = enableUrlContext ? gl.UrlContext() : null;
 
     if ((functionDeclarations == null || functionDeclarations.isEmpty) &&
         codeExecution == null &&
-        googleSearch == null) {
+        googleSearch == null &&
+        urlContext == null) {
       return null;
     }
 
@@ -532,6 +536,7 @@ extension ChatToolListMapper on List<Tool>? {
         functionDeclarations: functionDeclarations ?? const [],
         codeExecution: codeExecution,
         googleSearch: googleSearch,
+        urlContext: urlContext,
       ),
     ];
   }

--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_server_side_tools.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_server_side_tools.dart
@@ -5,4 +5,8 @@ enum GoogleServerSideTool {
 
   /// Google Search tool (Grounding).
   googleSearch,
+
+  /// Google URL context tool (URL context). Enables the model to query URLs in
+  /// the messages to retrieve additional context.
+  urlContext,
 }

--- a/packages/dartantic_ai/test/google_server_side_tools_e2e_test.dart
+++ b/packages/dartantic_ai/test/google_server_side_tools_e2e_test.dart
@@ -135,5 +135,24 @@ void main() {
       },
       timeout: const Timeout(Duration(minutes: 2)),
     );
+
+    test(
+      'URL Context: queries URLs and returns context',
+      () async {
+        final agent = Agent(
+          'google',
+          chatModelOptions: const GoogleChatModelOptions(
+            serverSideTools: {GoogleServerSideTool.urlContext},
+          ),
+        );
+
+        final result = await agent.send(
+          'Open this url and tell me the publisher of the package: https://pub.dev/packages/dartantic_ai',
+        );
+
+        expect(result.output, contains('sellsbrothers.com'));
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
   });
 }


### PR DESCRIPTION
Enable Google URL Context in chat tool mapping and request assembly when configured in GoogleChatModelOptions. Add an e2e test that verifies URL context can read a pub.dev page and return expected publisher data.