### PR TITLE
feat: Adding the max_turns option for xAI responses provider.

### DIFF
--- a/packages/dartantic_ai/lib/src/chat_models/xai_responses/xai_responses_chat_model.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/xai_responses/xai_responses_chat_model.dart
@@ -71,6 +71,13 @@ class XAIResponsesChatModel extends ChatModel<XAIResponsesChatModelOptions> {
     XAIResponsesChatModelOptions? options,
   ) => _applyXSearchStatic(existingTools, options);
 
+  /// Merges xAI-only top-level fields into a Responses `POST /responses` body.
+  @visibleForTesting
+  static void mergeXaiResponsesRequestBodyForTesting(
+    Map<String, dynamic> requestBody,
+    XAIResponsesChatModelOptions options,
+  ) => _mergeXaiResponsesRequestBodyStatic(requestBody, options);
+
   List<openai.ResponseTool> _buildFunctionTools() {
     final registeredTools = tools;
     if (registeredTools == null || registeredTools.isEmpty) {
@@ -179,6 +186,8 @@ class XAIResponsesChatModel extends ChatModel<XAIResponsesChatModelOptions> {
       truncation: invocation.parameters.truncation,
     ).toJson();
 
+    _mergeXaiResponsesRequestBodyStatic(requestBody, xaiOptions);
+
     final mcpTools = _buildMcpToolsStatic(xaiOptions.mcpTools);
     if (mcpTools.isNotEmpty) {
       final existing = requestBody['tools'] as List<dynamic>? ?? <dynamic>[];
@@ -198,6 +207,16 @@ class XAIResponsesChatModel extends ChatModel<XAIResponsesChatModelOptions> {
       endpoint: '/responses',
       body: requestBody,
     );
+  }
+
+  static void _mergeXaiResponsesRequestBodyStatic(
+    Map<String, dynamic> requestBody,
+    XAIResponsesChatModelOptions options,
+  ) {
+    final maxTurns = options.maxTurns;
+    if (maxTurns != null) {
+      requestBody['max_turns'] = maxTurns;
+    }
   }
 
   static List<dynamic> _applyXSearchStatic(

--- a/packages/dartantic_ai/lib/src/chat_models/xai_responses/xai_responses_chat_options.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/xai_responses/xai_responses_chat_options.dart
@@ -25,6 +25,7 @@ class XAIResponsesChatModelOptions extends ChatModelOptions {
     this.codeInterpreterConfig,
     this.xSearchConfig,
     this.mcpTools,
+    this.maxTurns,
   });
 
   /// Nucleus sampling parameter.
@@ -83,6 +84,13 @@ class XAIResponsesChatModelOptions extends ChatModelOptions {
 
   /// Configuration for one or more remote MCP tools.
   final List<XAIMcpToolConfig>? mcpTools;
+
+  /// Maximum assistant / server-side tool iterations for a single Responses
+  /// request (`max_turns` in the xAI API).
+  ///
+  /// See xAI tool documentation for behavior with client-side vs server-side
+  /// tools.
+  final int? maxTurns;
 }
 
 /// Reasoning effort levels for xAI Responses models.

--- a/packages/dartantic_ai/lib/src/providers/xai_responses_provider.dart
+++ b/packages/dartantic_ai/lib/src/providers/xai_responses_provider.dart
@@ -120,6 +120,7 @@ class XAIResponsesProvider
         webSearchConfig: options?.webSearchConfig,
         codeInterpreterConfig: options?.codeInterpreterConfig,
         mcpTools: options?.mcpTools,
+        maxTurns: options?.maxTurns,
       ),
     );
   }

--- a/packages/dartantic_ai/test/chat_models/xai_responses_chat_model_mapping_test.dart
+++ b/packages/dartantic_ai/test/chat_models/xai_responses_chat_model_mapping_test.dart
@@ -4,6 +4,24 @@ import 'package:test/test.dart';
 
 void main() {
   group('XAIResponsesChatModel option mapping', () {
+    test('merges max_turns into request body when maxTurns is set', () {
+      final body = <String, dynamic>{'model': 'grok-test'};
+      XAIResponsesChatModel.mergeXaiResponsesRequestBodyForTesting(
+        body,
+        const XAIResponsesChatModelOptions(maxTurns: 7),
+      );
+      expect(body['max_turns'], 7);
+    });
+
+    test('omits max_turns when maxTurns is null', () {
+      final body = <String, dynamic>{'model': 'grok-test'};
+      XAIResponsesChatModel.mergeXaiResponsesRequestBodyForTesting(
+        body,
+        const XAIResponsesChatModelOptions(),
+      );
+      expect(body.containsKey('max_turns'), isFalse);
+    });
+
     test('maps xAI options to internal Responses options', () {
       final mapped = XAIResponsesChatModel.toOpenAIOptionsForTesting(
         const XAIResponsesChatModelOptions(
@@ -146,8 +164,7 @@ void main() {
       expect(tools, isEmpty);
     });
 
-    test('serializes XAIXSearchConfig parameters into x_search tool entry',
-        () {
+    test('serializes XAIXSearchConfig parameters into x_search tool entry', () {
       final tools = XAIResponsesChatModel.applyXSearchToolForTesting(
         <dynamic>[],
         const XAIResponsesChatModelOptions(
@@ -178,9 +195,7 @@ void main() {
         <dynamic>[],
         const XAIResponsesChatModelOptions(
           serverSideTools: {XAIServerSideTool.xSearch},
-          xSearchConfig: XAIXSearchConfig(
-            excludedXHandles: ['spambot'],
-          ),
+          xSearchConfig: XAIXSearchConfig(excludedXHandles: ['spambot']),
         ),
       );
 

--- a/packages/dartantic_ai/test/chat_models/xai_responses_provider_test.dart
+++ b/packages/dartantic_ai/test/chat_models/xai_responses_provider_test.dart
@@ -74,6 +74,17 @@ void main() {
       );
     });
 
+    test('forwards maxTurns to chat model default options', () {
+      final provider = XAIResponsesProvider(apiKey: 'test-key');
+      final model =
+          provider.createChatModel(
+                options: const XAIResponsesChatModelOptions(maxTurns: 4),
+              )
+              as XAIResponsesChatModel;
+
+      expect(model.defaultOptions.maxTurns, 4);
+    });
+
     test('enableThinking preserves existing include entries', () {
       final provider = XAIResponsesProvider(apiKey: 'test-key');
       final model =


### PR DESCRIPTION
Adding the max_turns option for xAI responses provider. 

`max_turns` does **not** directly limit the number of individual tool calls. Instead, it limits the number of assistant turns in the agentic loop. During a single turn, the model may invoke multiple tools in parallel.

A single "turn" represents one iteration of the agentic reasoning loop:
1. The model analyzes the current context
2. The model decides to call one or more tools (potentially in parallel)
3. Tools execute and return results
4. The model processes the results

Docs:
https://docs.x.ai/developers/tools/tool-usage-details#understanding-turns-vs-tool-calls