### PR TITLE
feat(google): thinking levels, File Search, Maps grounding, and grounding metadata

### DIFF
--- a/packages/dartantic_ai/lib/src/agent/agent.dart
+++ b/packages/dartantic_ai/lib/src/agent/agent.dart
@@ -285,7 +285,9 @@ class Agent {
     // Detect if server-side tools are configured (e.g., Google Search)
     final hasServerSideTools = switch (chatModelOptions) {
       final GoogleChatModelOptions opts =>
-        opts.serverSideTools?.isNotEmpty ?? false,
+        (opts.serverSideTools?.isNotEmpty ?? false) ||
+            opts.fileSearch != null ||
+            opts.mapsGrounding != null,
       _ => false,
     };
 

--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_model.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_model.dart
@@ -106,7 +106,9 @@ class GoogleChatModel extends ChatModel<GoogleChatModelOptions> {
 
     final resolvedFileSearch = options?.fileSearch ?? defaultOptions.fileSearch;
     ga.FileSearch? fileSearchForRequest;
-    if (outputSchema == null && resolvedFileSearch != null) {
+    // File search is supported in Gemini 3+ and can be used with outputSchema
+    // so we do not remove it when outputSchema is provided.
+    if (resolvedFileSearch != null) {
       if (resolvedFileSearch.fileSearchStoreNames.isEmpty) {
         throw ArgumentError(
           'GoogleFileSearchToolConfig.fileSearchStoreNames must not be empty.',

--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_model.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_model.dart
@@ -8,6 +8,7 @@ import '../../providers/google_api_utils.dart';
 import 'google_chat_options.dart';
 import 'google_message_mappers.dart';
 import 'google_server_side_tools.dart';
+import 'google_thinking_config_mapper.dart';
 
 /// Wrapper around [Google AI for Developers](https://ai.google.dev/) API
 /// (aka Gemini API).
@@ -103,6 +104,28 @@ class GoogleChatModel extends ChatModel<GoogleChatModelOptions> {
         outputSchema == null &&
         serverSideTools.contains(GoogleServerSideTool.urlContext);
 
+    final resolvedFileSearch = options?.fileSearch ?? defaultOptions.fileSearch;
+    ga.FileSearch? fileSearchForRequest;
+    if (outputSchema == null && resolvedFileSearch != null) {
+      if (resolvedFileSearch.fileSearchStoreNames.isEmpty) {
+        throw ArgumentError(
+          'GoogleFileSearchToolConfig.fileSearchStoreNames must not be empty.',
+        );
+      }
+      fileSearchForRequest = ga.FileSearch(
+        fileSearchStoreNames: resolvedFileSearch.fileSearchStoreNames,
+        topK: resolvedFileSearch.topK,
+        metadataFilter: resolvedFileSearch.metadataFilter,
+      );
+    }
+
+    final resolvedMapsGrounding =
+        options?.mapsGrounding ?? defaultOptions.mapsGrounding;
+    final googleMapsForRequest =
+        outputSchema == null && resolvedMapsGrounding != null
+        ? ga.GoogleMaps(enableWidget: resolvedMapsGrounding.enableWidget)
+        : null;
+
     final generationConfig = _buildGenerationConfig(
       options: options,
       outputSchema: outputSchema,
@@ -129,6 +152,8 @@ class GoogleChatModel extends ChatModel<GoogleChatModelOptions> {
       enableCodeExecution: enableCodeExecution,
       enableGoogleSearch: enableGoogleSearch,
       enableUrlContext: enableUrlContext,
+      fileSearch: fileSearchForRequest,
+      googleMaps: googleMapsForRequest,
     );
 
     return ga.GenerateContentRequest(
@@ -204,17 +229,15 @@ class GoogleChatModel extends ChatModel<GoogleChatModelOptions> {
   }
 
   ga.ThinkingConfig? _buildThinkingConfig(GoogleChatModelOptions? options) {
-    if (!_enableThinking) return null;
+    final thinkingLevel =
+        options?.thinkingLevel ?? defaultOptions.thinkingLevel;
+    final thinkingBudgetTokens =
+        options?.thinkingBudgetTokens ?? defaultOptions.thinkingBudgetTokens;
 
-    // Default to dynamic thinking (-1) if no budget specified
-    final thinkingBudget =
-        options?.thinkingBudgetTokens ??
-        defaultOptions.thinkingBudgetTokens ??
-        -1;
-
-    return ga.ThinkingConfig(
-      includeThoughts: true,
-      thinkingBudget: thinkingBudget,
+    return buildGoogleGenerationThinkingConfig(
+      enableThinking: _enableThinking,
+      thinkingBudgetTokens: thinkingBudgetTokens,
+      thinkingLevel: thinkingLevel,
     );
   }
 

--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_options.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_options.dart
@@ -131,7 +131,7 @@ class GoogleChatModelOptions extends ChatModelOptions {
   /// 3+).
   ///
   /// This is sent to the API whenever set; it does not require
-  /// `Agent(..., enableThinking: true)`. Enable enableThinking as well
+  /// `Agent(..., enableThinking: true)`. Set `enableThinking: true` as well
   /// if you want thought summaries (`ThinkingPart`) in addition to level
   /// control.
   ///

--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_options.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_chat_options.dart
@@ -25,6 +25,9 @@ class GoogleChatModelOptions extends ChatModelOptions {
     this.serverSideTools,
     this.functionCallingMode,
     this.allowedFunctionNames,
+    this.thinkingLevel,
+    this.fileSearch,
+    this.mapsGrounding,
   });
 
   /// The model to use (e.g. 'gemini-1.5-pro').
@@ -123,6 +126,35 @@ class GoogleChatModelOptions extends ChatModelOptions {
   /// )
   /// ```
   final int? thinkingBudgetTokens;
+
+  /// Optional thinking depth for models that use thinking levels (e.g. Gemini
+  /// 3+).
+  ///
+  /// This is sent to the API whenever set; it does not require
+  /// `Agent(..., enableThinking: true)`. Enable enableThinking as well
+  /// if you want thought summaries (`ThinkingPart`) in addition to level
+  /// control.
+  ///
+  /// Do not set [thinkingBudgetTokens] when this is set; the API rejects using
+  /// both together.
+  final GoogleThinkingLevel? thinkingLevel;
+
+  /// Enables the Gemini File Search tool against the given file search stores.
+  ///
+  /// Omit or set to null to disable. When set,
+  /// [GoogleFileSearchToolConfig] must list at least one store name (e.g.
+  /// `fileSearchStores/my-store-id`).
+  ///
+  /// Like other server-side tools, this is omitted when a typed output schema
+  /// is used in the same request (double-agent phase handles that separately).
+  final GoogleFileSearchToolConfig? fileSearch;
+
+  /// Enables Google Maps grounding for geospatial context in responses.
+  ///
+  /// Omit or set to null to disable. A non-null value enables the tool; use
+  /// [GoogleMapsGroundingOptions.enableWidget] to request widget context
+  /// tokens in grounding metadata when supported.
+  final GoogleMapsGroundingOptions? mapsGrounding;
 
   /// The server-side tools to enable.
   final Set<GoogleServerSideTool>? serverSideTools;
@@ -245,4 +277,55 @@ enum GoogleFunctionCallingMode {
   /// limited to those functions. Otherwise, any provided function may be
   /// called.
   validated,
+}
+
+/// Reasoning depth for Gemini models that support thinking levels (e.g. Gemini
+/// 3).
+///
+/// See Gemini API documentation for model-specific support.
+enum GoogleThinkingLevel {
+  /// Minimal thinking tokens (e.g. Gemini 3 Flash).
+  minimal,
+
+  /// Lower latency and cost; simple tasks.
+  low,
+
+  /// Balanced (e.g. Gemini 3 Flash).
+  medium,
+
+  /// Deeper reasoning; default for many Gemini 3 models.
+  high,
+}
+
+/// Configuration for Gemini File Search (semantic retrieval from file stores).
+@immutable
+class GoogleFileSearchToolConfig {
+  /// Creates file search tool configuration.
+  ///
+  /// [fileSearchStoreNames] must be non-empty when passed to the API.
+  const GoogleFileSearchToolConfig({
+    required this.fileSearchStoreNames,
+    this.topK,
+    this.metadataFilter,
+  });
+
+  /// Resource names of file search stores to query.
+  final List<String> fileSearchStoreNames;
+
+  /// Optional number of semantic chunks to retrieve.
+  final int? topK;
+
+  /// Optional metadata filter expression for documents and chunks.
+  final String? metadataFilter;
+}
+
+/// Options for Google Maps grounding on Gemini.
+@immutable
+class GoogleMapsGroundingOptions {
+  /// Creates Maps grounding options.
+  const GoogleMapsGroundingOptions({this.enableWidget});
+
+  /// When true, responses may include a widget context token in grounding
+  /// metadata for rendering a Maps widget.
+  final bool? enableWidget;
 }

--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_message_mappers.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_message_mappers.dart
@@ -235,6 +235,11 @@ extension MessageListMapper on List<ChatMessage> {
 /// Extension on [ga.GenerateContentResponse] to convert to [ChatResult].
 extension GenerateContentResponseMapper on ga.GenerateContentResponse {
   /// Converts this response to a [ChatResult].
+  ///
+  /// Populates [ChatResult.metadata] with `model`, optional `model_version`,
+  /// `block_reason`, `safety_ratings`, `citation_metadata`,
+  /// `grounding_metadata` (JSON from [ga.GroundingMetadata.toJson] when
+  /// present and non-empty), and code-execution fields when applicable.
   ChatResult<ChatMessage> toChatResult(String model) {
     final candidateList = candidates;
     if (candidateList == null || candidateList.isEmpty) {
@@ -380,6 +385,14 @@ extension GenerateContentResponseMapper on ga.GenerateContentResponse {
           .toList(growable: false);
     }
 
+    final grounding = candidate.groundingMetadata;
+    if (grounding != null) {
+      final groundingJson = grounding.toJson();
+      if (groundingJson.isNotEmpty) {
+        metadata['grounding_metadata'] = groundingJson;
+      }
+    }
+
     if (executableCodeParts.isNotEmpty) {
       metadata['executable_code'] = executableCodeParts
           .map((code) => code.toJson())
@@ -473,6 +486,8 @@ extension ChatToolListMapper on List<Tool>? {
     required bool enableCodeExecution,
     required bool enableGoogleSearch,
     required bool enableUrlContext,
+    ga.FileSearch? fileSearch,
+    ga.GoogleMaps? googleMaps,
   }) {
     final hasTools = this != null && this!.isNotEmpty;
     _logger.fine(
@@ -480,6 +495,8 @@ extension ChatToolListMapper on List<Tool>? {
       'enableCodeExecution=$enableCodeExecution, '
       'enableGoogleSearch=$enableGoogleSearch, '
       'enableUrlContext=$enableUrlContext, '
+      'fileSearch=${fileSearch != null}, '
+      'googleMaps=${googleMaps != null}, '
       'toolCount=${this?.length ?? 0}',
     );
 
@@ -502,7 +519,9 @@ extension ChatToolListMapper on List<Tool>? {
     if ((functionDeclarations == null || functionDeclarations.isEmpty) &&
         codeExecution == null &&
         googleSearch == null &&
-        urlContext == null) {
+        urlContext == null &&
+        fileSearch == null &&
+        googleMaps == null) {
       return null;
     }
 
@@ -512,6 +531,8 @@ extension ChatToolListMapper on List<Tool>? {
         codeExecution: codeExecution,
         googleSearch: googleSearch,
         urlContext: urlContext,
+        fileSearch: fileSearch,
+        googleMaps: googleMaps,
       ),
     ];
   }

--- a/packages/dartantic_ai/lib/src/chat_models/google_chat/google_thinking_config_mapper.dart
+++ b/packages/dartantic_ai/lib/src/chat_models/google_chat/google_thinking_config_mapper.dart
@@ -1,0 +1,54 @@
+import 'package:googleai_dart/googleai_dart.dart' as ga;
+
+import 'google_chat_options.dart';
+
+/// Builds [ga.ThinkingConfig] for Gemini generate-content from Dartantic
+/// options.
+///
+/// [thinkingLevel] is sent whenever it is set; it controls reasoning depth on
+/// Gemini 3+ and does not require [enableThinking]. When [enableThinking] is
+/// also true, [ga.ThinkingConfig.includeThoughts] is set so thought summaries
+/// are returned (see Gemini thinking docs).
+///
+/// The [thinkingBudgetTokens] path only applies when [enableThinking] is true
+/// (Gemini 2.5-style budget). When [enableThinking] is false and no level is
+/// set, returns null.
+///
+/// Throws [ArgumentError] if both [thinkingLevel] and
+/// [thinkingBudgetTokens] are non-null, because the API does not allow
+/// combining thinking level (Gemini 3+) with thinking budget (Gemini
+/// 2.5-style).
+ga.ThinkingConfig? buildGoogleGenerationThinkingConfig({
+  required bool enableThinking,
+  int? thinkingBudgetTokens,
+  GoogleThinkingLevel? thinkingLevel,
+}) {
+  if (thinkingLevel != null && thinkingBudgetTokens != null) {
+    throw ArgumentError(
+      'GoogleChatModelOptions: cannot set both thinkingLevel (Gemini 3+) and '
+      'thinkingBudgetTokens (Gemini 2.5-style thinking budget). Use one or '
+      'the other.',
+    );
+  }
+
+  if (thinkingLevel != null) {
+    final gaLevel = switch (thinkingLevel) {
+      GoogleThinkingLevel.minimal => ga.ThinkingLevel.minimal,
+      GoogleThinkingLevel.low => ga.ThinkingLevel.low,
+      GoogleThinkingLevel.medium => ga.ThinkingLevel.medium,
+      GoogleThinkingLevel.high => ga.ThinkingLevel.high,
+    };
+    return ga.ThinkingConfig(
+      includeThoughts: enableThinking ? true : null,
+      thinkingLevel: gaLevel,
+    );
+  }
+
+  if (!enableThinking) return null;
+
+  final thinkingBudget = thinkingBudgetTokens ?? -1;
+  return ga.ThinkingConfig(
+    includeThoughts: true,
+    thinkingBudget: thinkingBudget,
+  );
+}

--- a/packages/dartantic_ai/lib/src/providers/google_provider.dart
+++ b/packages/dartantic_ai/lib/src/providers/google_provider.dart
@@ -115,6 +115,9 @@ class GoogleProvider
         responseSchema: options?.responseSchema,
         safetySettings: options?.safetySettings,
         thinkingBudgetTokens: options?.thinkingBudgetTokens,
+        thinkingLevel: options?.thinkingLevel,
+        fileSearch: options?.fileSearch,
+        mapsGrounding: options?.mapsGrounding,
         serverSideTools: options?.serverSideTools,
       ),
     );

--- a/packages/dartantic_ai/pubspec.yaml
+++ b/packages/dartantic_ai/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   anthropic_sdk_dart: ^1.2.0
   collection: ^1.19.1
   dartantic_interface: ^4.0.0
-  googleai_dart: ^5.0.0
+  googleai_dart: ^5.0.1
   html: ^0.15.6
   http: ^1.6.0
   logging: ^1.3.0

--- a/packages/dartantic_ai/test/google_chat_capabilities_test.dart
+++ b/packages/dartantic_ai/test/google_chat_capabilities_test.dart
@@ -1,0 +1,140 @@
+import 'package:dartantic_ai/src/chat_models/google_chat/google_chat_options.dart';
+import 'package:dartantic_ai/src/chat_models/google_chat/google_message_mappers.dart';
+import 'package:dartantic_ai/src/chat_models/google_chat/google_thinking_config_mapper.dart';
+import 'package:dartantic_interface/dartantic_interface.dart';
+import 'package:googleai_dart/googleai_dart.dart' as ga;
+import 'package:test/test.dart';
+
+void main() {
+  group('GenerateContentResponseMapper.toChatResult', () {
+    test('maps groundingMetadata into result metadata', () {
+      const response = ga.GenerateContentResponse(
+        candidates: [
+          ga.Candidate(
+            content: ga.Content.model([ga.TextPart('answer')]),
+            finishReason: ga.FinishReason.stop,
+            groundingMetadata: ga.GroundingMetadata(
+              webSearchQueries: ['dart lang'],
+            ),
+          ),
+        ],
+      );
+
+      final result = response.toChatResult('gemini-test');
+
+      final gm = result.metadata['grounding_metadata'] as Map<String, dynamic>?;
+      expect(gm, isNotNull);
+      expect(gm!['webSearchQueries'], equals(['dart lang']));
+    });
+  });
+
+  group('ChatToolListMapper.toToolList', () {
+    test(
+      'includes fileSearch in tool JSON when only file search is enabled',
+      () {
+        List<Tool>? noTools;
+        final list = noTools.toToolList(
+          enableCodeExecution: false,
+          enableGoogleSearch: false,
+          enableUrlContext: false,
+          fileSearch: const ga.FileSearch(
+            fileSearchStoreNames: ['fileSearchStores/abc'],
+            topK: 3,
+            metadataFilter: 'region = us',
+          ),
+        );
+
+        expect(list, isNotNull);
+        final json = list!.single.toJson();
+        expect(json['fileSearch'], isA<Map<String, dynamic>>());
+        final fs = json['fileSearch']! as Map<String, dynamic>;
+        expect(fs['fileSearchStoreNames'], ['fileSearchStores/abc']);
+        expect(fs['topK'], 3);
+        expect(fs['metadataFilter'], 'region = us');
+      },
+    );
+
+    test('includes googleMaps in tool JSON when only maps is enabled', () {
+      List<Tool>? noTools;
+      final list = noTools.toToolList(
+        enableCodeExecution: false,
+        enableGoogleSearch: false,
+        enableUrlContext: false,
+        googleMaps: const ga.GoogleMaps(enableWidget: true),
+      );
+
+      expect(list, isNotNull);
+      final json = list!.single.toJson();
+      expect(json['googleMaps'], isA<Map<String, dynamic>>());
+      final gm = json['googleMaps']! as Map<String, dynamic>;
+      expect(gm['enableWidget'], true);
+    });
+  });
+
+  group('buildGoogleGenerationThinkingConfig', () {
+    test('returns null when thinking disabled and no thinking level', () {
+      expect(
+        buildGoogleGenerationThinkingConfig(
+          enableThinking: false,
+          thinkingBudgetTokens: 100,
+          thinkingLevel: null,
+        ),
+        isNull,
+      );
+    });
+
+    test('thinking level applies without enableThinking', () {
+      final config = buildGoogleGenerationThinkingConfig(
+        enableThinking: false,
+        thinkingBudgetTokens: null,
+        thinkingLevel: GoogleThinkingLevel.low,
+      );
+      expect(config, isNotNull);
+      expect(config!.thinkingLevel, ga.ThinkingLevel.low);
+      expect(config.thinkingBudget, isNull);
+      expect(config.includeThoughts, isNull);
+    });
+
+    test('thinking level with enableThinking sets includeThoughts', () {
+      final config = buildGoogleGenerationThinkingConfig(
+        enableThinking: true,
+        thinkingBudgetTokens: null,
+        thinkingLevel: GoogleThinkingLevel.high,
+      );
+      expect(config, isNotNull);
+      expect(config!.thinkingLevel, ga.ThinkingLevel.high);
+      expect(config.thinkingBudget, isNull);
+      expect(config.includeThoughts, true);
+    });
+
+    test('uses explicit thinking budget when level is not set', () {
+      final config = buildGoogleGenerationThinkingConfig(
+        enableThinking: true,
+        thinkingBudgetTokens: 2048,
+        thinkingLevel: null,
+      );
+      expect(config!.thinkingBudget, 2048);
+      expect(config.thinkingLevel, isNull);
+    });
+
+    test('defaults thinking budget to -1 when neither level nor budget', () {
+      final config = buildGoogleGenerationThinkingConfig(
+        enableThinking: true,
+        thinkingBudgetTokens: null,
+        thinkingLevel: null,
+      );
+      expect(config!.thinkingBudget, -1);
+    });
+
+    test('throws ArgumentError when both level and budget are set', () {
+      expect(
+        () => buildGoogleGenerationThinkingConfig(
+          enableThinking: false,
+          thinkingBudgetTokens: 100,
+          thinkingLevel: GoogleThinkingLevel.low,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}

--- a/packages/dartantic_ai/test/google_server_side_tools_e2e_test.dart
+++ b/packages/dartantic_ai/test/google_server_side_tools_e2e_test.dart
@@ -1,9 +1,171 @@
 // NEVER check for API keys in tests. Dartantic already validates API keys
 // and throws a clear exception if one is missing. Tests should fail loudly
 // when credentials are unavailable, not silently skip.
+//
+// File Search E2E: creates or reuses a store
+// [kDartanticE2eStoreDisplayName] and uploads
+// [kDartanticE2eDocumentDisplayName] if missing. See
+// https://ai.google.dev/gemini-api/docs/file-search
+
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:dartantic_ai/dartantic_ai.dart';
+import 'package:googleai_dart/googleai_dart.dart' as ga;
 import 'package:test/test.dart';
+
+/// Display name for the shared E2E File Search store (stable across runs).
+const String kDartanticE2eStoreDisplayName = 'dartantic_ai_e2e_file_search';
+
+/// Display name for the fixture document inside the store.
+const String kDartanticE2eDocumentDisplayName = 'dartantic_e2e_retrieval_fact';
+
+/// Token the model must recover from file search over the fixture.
+const String kDartanticE2eRetrievalToken = 'DARTANTIC_E2E_FS_TOKEN_PYRAMID_9';
+
+/// Text uploaded into the File Search store for retrieval tests.
+String get kDartanticE2eFileSearchBody =>
+    '''
+Dartantic File Search E2E fixture document.
+
+Verification token: $kDartanticE2eRetrievalToken
+
+The fixture answer phrase is: red-pyramid-nine
+''';
+
+Future<ga.FileSearchStore?> _findFileSearchStoreByDisplayName(
+  ga.GoogleAIClient client,
+  String displayName,
+) async {
+  String? pageToken;
+  do {
+    final res = await client.fileSearchStores.list(
+      pageSize: 20,
+      pageToken: pageToken,
+    );
+    for (final store in res.fileSearchStores ?? const <ga.FileSearchStore>[]) {
+      if (store.displayName == displayName) return store;
+    }
+    pageToken = res.nextPageToken;
+  } while (pageToken != null && pageToken.isNotEmpty);
+  return null;
+}
+
+Future<List<ga.Document>> _listAllStoreDocuments(
+  ga.GoogleAIClient client,
+  String storeResourceName,
+) async {
+  final out = <ga.Document>[];
+  String? pageToken;
+  do {
+    final res = await client.fileSearchStores.listDocuments(
+      parent: storeResourceName,
+      pageSize: 20,
+      pageToken: pageToken,
+    );
+    out.addAll(res.documents ?? const <ga.Document>[]);
+    pageToken = res.nextPageToken;
+  } while (pageToken != null && pageToken.isNotEmpty);
+  return out;
+}
+
+Future<void> _waitForDocumentActive(
+  ga.GoogleAIClient client,
+  String documentResourceName, {
+  Duration pollInterval = const Duration(seconds: 2),
+  int maxAttempts = 45,
+}) async {
+  for (var i = 0; i < maxAttempts; i++) {
+    final doc = await client.fileSearchStores.getDocument(
+      name: documentResourceName,
+    );
+    if (doc.state == ga.DocumentState.active) return;
+    if (doc.state == ga.DocumentState.failed) {
+      throw StateError(
+        'File Search document failed to index: $documentResourceName',
+      );
+    }
+    await Future<void>.delayed(pollInterval);
+  }
+  throw StateError(
+    'Timed out waiting for File Search document to become active: '
+    '$documentResourceName',
+  );
+}
+
+/// Ensures a File Search store and indexed test document exist, then returns
+/// the store resource name (e.g. `fileSearchStores/...`).
+///
+/// Reuses a store with [kDartanticE2eStoreDisplayName]. Uploads
+/// [kDartanticE2eFileSearchBody] when no active document with
+/// [kDartanticE2eDocumentDisplayName] is present.
+Future<String> ensureDartanticE2eFileSearchStoreReady(
+  ga.GoogleAIClient client,
+) async {
+  var store = await _findFileSearchStoreByDisplayName(
+    client,
+    kDartanticE2eStoreDisplayName,
+  );
+  store ??= await client.fileSearchStores.create(
+    displayName: kDartanticE2eStoreDisplayName,
+  );
+  final storeName = store.name;
+  if (storeName == null || storeName.isEmpty) {
+    throw StateError('File Search store has no name: $store');
+  }
+
+  final docs = await _listAllStoreDocuments(client, storeName);
+  for (final doc in docs) {
+    if (doc.displayName != kDartanticE2eDocumentDisplayName) continue;
+    final name = doc.name;
+    if (name == null || name.isEmpty) continue;
+    if (doc.state == ga.DocumentState.active) return storeName;
+    if (doc.state == ga.DocumentState.pending) {
+      await _waitForDocumentActive(client, name);
+      return storeName;
+    }
+    if (doc.state == ga.DocumentState.failed) {
+      await client.fileSearchStores.deleteDocument(name: name);
+    }
+  }
+
+  final bytes = utf8.encode(kDartanticE2eFileSearchBody);
+  final upload = await client.fileSearchStores.upload(
+    parent: storeName,
+    bytes: bytes,
+    fileName: 'dartantic_e2e_fixture.txt',
+    mimeType: 'text/plain',
+    request: const ga.UploadToFileSearchStoreRequest(
+      displayName: kDartanticE2eDocumentDisplayName,
+      mimeType: 'text/plain',
+    ),
+  );
+  final docName = upload.documentName;
+  if (docName == null || docName.isEmpty) {
+    throw StateError('upload_to_file_search_store returned no documentName');
+  }
+  await _waitForDocumentActive(client, docName);
+  return storeName;
+}
+
+/// `grounding_metadata` from Maps should name the Walt Disney Family Museum
+/// for queries about museums near the Presidio.
+void expectGroundingIncludesDisneyFamilyMuseum(Map<String, dynamic> metadata) {
+  final grounding = metadata['grounding_metadata'];
+  expect(
+    grounding,
+    isA<Map<String, dynamic>>(),
+    reason: 'Expected non-null grounding_metadata from Maps grounding',
+  );
+  final blob = jsonEncode(grounding).toLowerCase();
+  expect(
+    blob.contains('disney') && blob.contains('museum'),
+    isTrue,
+    reason:
+        'Grounding should reference the Walt Disney Family Museum '
+        '(or similar): ${jsonEncode(grounding)}',
+  );
+}
 
 void main() {
   group('Google server-side tooling E2E', () {
@@ -153,6 +315,184 @@ void main() {
         expect(result.output, contains('sellsbrothers.com'));
       },
       timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'thinkingLevel high vs low: same prompt, low finishes faster',
+      () async {
+        const prompt = 'Whats 2+2? Respond with just the answer.';
+
+        Future<Duration> timeSend(GoogleThinkingLevel level) async {
+          final agent = Agent(
+            'google:gemini-3-flash-preview',
+            chatModelOptions: GoogleChatModelOptions(thinkingLevel: level),
+          );
+          final sw = Stopwatch()..start();
+          final result = await agent.send(prompt);
+          sw.stop();
+          expect(result.output.toLowerCase(), contains('4'));
+          return sw.elapsed;
+        }
+
+        // High first so the low run avoids connection cold-start bias.
+        final highDuration = await timeSend(GoogleThinkingLevel.high);
+        final lowDuration = await timeSend(GoogleThinkingLevel.low);
+
+        expect(
+          lowDuration,
+          lessThan(highDuration),
+          reason:
+              'low thinkingLevel should be faster than high for the same '
+              'prompt (high=${highDuration.inMilliseconds}ms, '
+              'low=${lowDuration.inMilliseconds}ms)',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'Maps grounding: Presidio museums prompt surfaces Disney Family Museum',
+      () async {
+        final agent = Agent(
+          'google:gemini-2.5-flash',
+          chatModelOptions: const GoogleChatModelOptions(
+            mapsGrounding: GoogleMapsGroundingOptions(),
+          ),
+        );
+
+        final result = await agent.send(
+          'Using Google Maps grounding: what museums are near Presidio Park in '
+          'San Francisco? List a few examples in a short answer.',
+        );
+
+        expect(result.output.toLowerCase(), contains('museum'));
+        expectGroundingIncludesDisneyFamilyMuseum(result.metadata);
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'Maps grounding with typed output: double agent and Disney in grounding',
+      () async {
+        final outputSchema = Schema.fromMap({
+          'type': 'object',
+          'properties': {
+            'examples': {
+              'type': 'array',
+              'items': {'type': 'string'},
+              'description': 'Museum names near the Presidio',
+            },
+          },
+          'required': ['examples'],
+        });
+
+        final agent = Agent(
+          'google:gemini-2.5-flash',
+          chatModelOptions: const GoogleChatModelOptions(
+            mapsGrounding: GoogleMapsGroundingOptions(),
+          ),
+        );
+
+        final result = await agent.sendFor<Map<String, dynamic>>(
+          'Using Google Maps grounding: list museums near Presidio Park in San '
+          'Francisco. Put museum names in the examples array of the JSON '
+          'schema.',
+          outputSchema: outputSchema,
+          outputFromJson: (json) => json,
+        );
+
+        final examples = result.output['examples'] as List<dynamic>?;
+        expect(examples, isNotNull);
+        expect(examples, isNotEmpty);
+        expectGroundingIncludesDisneyFamilyMuseum(result.metadata);
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'File Search: ensures fixture document then answers from retrieval',
+      () async {
+        final apiKey = Platform.environment[GoogleProvider.defaultApiKeyName]!;
+        final client = ga.GoogleAIClient(
+          config: ga.GoogleAIConfig(authProvider: ga.ApiKeyProvider(apiKey)),
+        );
+        late final String storeName;
+        try {
+          storeName = await ensureDartanticE2eFileSearchStoreReady(client);
+        } finally {
+          client.close();
+        }
+
+        final agent = Agent(
+          'google:gemini-3-flash-preview',
+          chatModelOptions: GoogleChatModelOptions(
+            fileSearch: GoogleFileSearchToolConfig(
+              fileSearchStoreNames: [storeName],
+            ),
+          ),
+        );
+
+        final result = await agent.send(
+          'Use file search on the configured stores only. What is the '
+          'verification token string in the fixture document? Reply with '
+          'only that token.',
+        );
+
+        expect(result.output, contains(kDartanticE2eRetrievalToken));
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+    );
+
+    test(
+      'File Search with typed output: fixture then structured answer',
+      () async {
+        final apiKey = Platform.environment[GoogleProvider.defaultApiKeyName]!;
+        final client = ga.GoogleAIClient(
+          config: ga.GoogleAIConfig(authProvider: ga.ApiKeyProvider(apiKey)),
+        );
+        late final String storeName;
+        try {
+          storeName = await ensureDartanticE2eFileSearchStoreReady(client);
+        } finally {
+          client.close();
+        }
+
+        final outputSchema = Schema.fromMap({
+          'type': 'object',
+          'properties': {
+            'token': {'type': 'string'},
+            'phrase': {'type': 'string'},
+          },
+          'required': ['token', 'phrase'],
+        });
+
+        final agent = Agent(
+          'google:gemini-3-flash-preview',
+          chatModelOptions: GoogleChatModelOptions(
+            fileSearch: GoogleFileSearchToolConfig(
+              fileSearchStoreNames: [storeName],
+            ),
+          ),
+        );
+
+        final result = await agent.sendFor<Map<String, dynamic>>(
+          'Use file search on the configured stores. Return the verification '
+          'token and the fixture answer phrase (red-pyramid-nine) in the JSON '
+          'schema.',
+          outputSchema: outputSchema,
+          outputFromJson: (json) => json,
+        );
+
+        expect(
+          result.output['token'].toString().trim(),
+          kDartanticE2eRetrievalToken,
+        );
+        expect(
+          result.output['phrase'].toString().toLowerCase(),
+          contains('red-pyramid-nine'),
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
     );
   });
 }


### PR DESCRIPTION
## Summary

Extends the Google Gemini provider with **thinking levels** (Gemini 3+), **File Search** (semantic retrieval from configured stores), and **Google Maps grounding**, and exposes **`grounding_metadata`** on chat results when the API returns it.

## Changes

- **`GoogleChatModelOptions`**: `thinkingLevel` (`GoogleThinkingLevel`), `fileSearch` (`GoogleFileSearchToolConfig`), `mapsGrounding` (`GoogleMapsGroundingOptions`).
- **Thinking**: `buildGoogleGenerationThinkingConfig()` maps levels to the Gemini API, supports thought summaries when `enableThinking` is true, keeps budget-based thinking for 2.5-style usage, and **throws** if both `thinkingLevel` and `thinkingBudgetTokens` are set (API-incompatible combination).
- **Requests**: File Search / Maps are passed into the generate-content tool list alongside existing server-side tools; File Search requires non-empty store names when enabled.
- **`Agent`**: Treats File Search and Maps as server-side tooling for orchestration so **typed output + tools** still uses the Google double-agent path when needed.
- **Results**: `ChatResult.metadata['grounding_metadata']` populated from `GroundingMetadata` when present.

## Tests

- **Unit**: `google_chat_capabilities_test.dart` — grounding in metadata, `fileSearch` / `googleMaps` in tool JSON, thinking config behavior.
- **E2E** (API key): `google_server_side_tools_e2e_test.dart` — thinking level comparison, Maps grounding (plain + typed output), File Search fixture setup and retrieval (plain + typed output).

## Notes for reviewers

- File Search E2E tests create or reuse a named store and upload a small fixture; they require a valid Gemini API key and may have side effects in the project’s File Search resources.
- Maps E2E assertions check grounding text for a known landmark near the Presidio; wording may vary slightly with model updates.